### PR TITLE
Add better subdirectory handling

### DIFF
--- a/lib/npm/elm/rails/dependency_processor.rb
+++ b/lib/npm/elm/rails/dependency_processor.rb
@@ -26,9 +26,10 @@ module Npm
             module_name = match[:module]
             # e.g. Quiz/QuestionStore
             dependency_logical_name = module_name.tr(".", "/")
-            # e.g. ./Quiz/QuestionStore.elm
-            dependency_path =
-              path.join("..", "#{dependency_logical_name}.elm")
+            # e.g. elm/ProjectName
+            basepath = Pathname.new(File.dirname(context.pathname))
+            # e.g. elm/ProjectName/Quiz/QuestionStore.elm
+            dependency_path = basepath.join("#{dependency_logical_name}.elm")
 
             # If we don't find the dependency in our filesystem, assume it's
             # because it comes in through a third-party package rather than our


### PR DESCRIPTION
Some folks noticed an issue where changes to files in subdirectories weren't being picked up.

This was caused by the dependency processor assuming that the current file was the project root, so if a file in `Views/` referenced another file in `Views/`, the resulting path would end up as `Views/Views/File.elm`

This is why the problem was hard to nail down: it only affected files in a subdirectory that were imported by a file in a subdirectory.

This base path fix should take care of the problem moving forward.