### PR TITLE
Point to a fork of ruby-elm-compiler.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 
-gem 'elm-compiler', '~> 0.4.0'
+gem 'elm-compiler', '~> 0.4.0', git: 'git@github.com:RBM-Technologies/ruby-elm-compiler'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,18 @@
+GIT
+  remote: git@github.com:RBM-Technologies/ruby-elm-compiler
+  revision: c94bd735c835652386d55334334681448377fc02
+  specs:
+    elm-compiler (0.4.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  elm-compiler (~> 0.4.0)!
+
+BUNDLED WITH
+   2.0.1


### PR DESCRIPTION
Moved the git reference from vmm into this repo. My PR against `npm-elm-rails` has been open and ignored for 22 days, so I'm considering that project abandoned, and pointing to our own fork instead.